### PR TITLE
Add VerdeDesk - freelancer tax tool for Portugal

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Valinor Finance](https://www.valinorfinance.com/): Review platform built specifically for finding financial advisors.
 *   [Wallet Finder AI](https://www.walletfinder.ai/): Track top wallets and trades across blockchains with real-time insights.
 *   [Zola Analytics](https://www.zolaanalytics.com/): Turn financial data into instant charts and reports using simple language.
+*   [VerdeDesk](https://verdedesk.vercel.app/): Issue Portuguese green receipts (recibos verdes) and stay tax-compliant as a freelancer in Portugal — in plain English.
 
 ### Health & Lifestyle
 


### PR DESCRIPTION
[VerdeDesk](https://verdedesk.vercel.app) is a micro-SaaS that helps English-speaking freelancers in Portugal issue green receipts (recibos verdes) and stay tax-compliant — in plain English.

Portugal's government tax portal (Portal das Financas) has no English version, forcing 9,000+ D8 visa holders to hire accountants at EUR 80-165/month just to issue invoices. VerdeDesk wraps the portal with an English interface at EUR 9/month.

Added to the **Finance** section.