### PR TITLE
Add Shotlab to the list of Design tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [PimpMySnap](https://pimpmysnap.com): Transform screenshots with animations, custom backgrounds, highlights, frames, and text.
 *   [Pixvify AI](https://pixvify.com/): Free AI photo generator.
 *   [Rupert AI](https://www.getrupert.com/): Train custom AI models and automate marketing workflows.
+*   [Shotlab](https://www.shotlab.pro): Turn boring screenshots into scroll-stopping visuals with stunning backgrounds, frames, emojis, cool stickers, annotations and text.
 *   [Unblurimage AI](https://unblurimage.ai/): Enhance photos using AI, making blurry pictures clear and beautiful.
 *   [Velocity](https://www.figma.com/community/plugin/1397952939678206595/ai-design-reviews-user-simulations-then-human-feedback-1min): Instant AI-powered UX feedback for prototypes directly inside Figma.
 *   [Venngage AI Infographic Generator](https://venngage.com/ai-tools/infographic-generator): Turn text prompts into customizable, professional infographics in just seconds.


### PR DESCRIPTION
Added [Shotlab ](https://shotlab.pro)(a screenshot editor that turns boring screenshots into scroll-stopping visuals, instantly) to the list of Design tools.