### PR TITLE
Add Micro-SaaS Runway Price Floor Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [GOSH](https://gosh.app): Free AI price tracker that alerts you when prices drop.
 *   [KitchenCost](https://kitchencost.app/): Recipe cost calculator for chefs and small food businesses.
 *   [MagicTask](https://magictask.io/): Turn tasks into a fun game with points, rewards, and leaderboards.
+*   [Micro-SaaS Runway Price Floor Calculator](https://micro-saas-runway-price-floor-calculator.vercel.app/): Estimate a micro-SaaS price floor, break-even customers, and runway gap in the browser.
 *   [MyndField](https://myndfield.ai/): World's First Decision Engine.
 *   [Packgine](https://packgine.ai/): Instant packaging analysis and environmental compliance reports.
 *   [Plotzy](https://plotzy.ai): AI Co-Pilot For The Commercial Real Estate Industry.


### PR DESCRIPTION
Adds a free browser calculator for bootstrapped micro-SaaS founders to estimate a price floor, break-even customers, and runway gap. Duplicate checks found no existing entry or open PR for this title or URL.