### PR TITLE
Add igly.ai to design tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Ecommerce Design](https://ecomm.design/): Curated gallery of 4,000+ ecommerce website designs for inspiration.
 *   [FLUX AI ART](https://fluxaiart.ai/): AI-powered platform for image generation, editing, and free unlimited storage.
 *   [GenDesigns](https://gendesigns.ai/): AI Mobile App Design Generator.
+*   [igly.ai](https://igly.ai): AI image editor for background removal, inpainting, upscaling, and generative fill.
 *   [ImgUpscaler AI](https://imgupscaler.ai/): Enhance and upscale images or videos with sharper, detailed, high-quality visuals.
 *   [Kosmik](https://www.kosmik.app/): Visual research app that auto-tags, organizes, and finds related content.
 *   [Pawtrait](https://www.pawtrait.art/): Custom AI pet portraits in 30+ styles.


### PR DESCRIPTION
## Summary
- Add igly.ai to the Design category
- Keep the listing consistent with the existing directory format

## Why
igly.ai is an AI image editing SaaS for background removal, inpainting, upscaling, and generative fill, which fits the existing design and image tooling entries.

Demo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is