### PR TITLE
Add PDFExcel to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Nook Savings](http://nookapp.xyz/): Saving app that earns 3x more than your bank account.
 *   [Panem](https://panem.co): AI Powered SaaS Spend Management.
 *   [PayCalculator](https://paycalculator.ai/): PayCalculator.ai instantly calculates take-home pay with tax breakdowns.
+*   [PDFExcel](https://pdfexcel.ai/): AI tool that converts any PDF — including scanned and photographed documents — into Excel, CSV, or Google Sheets.
 *   [Property Forecast](https://propertyforecast.co/): Data analytics for real estate investors.
 *   [Receipt Faker](https://receiptfaker.com/): Make receipts fast with easy templates you can edit and download.
 *   [Salary Calculator](https://salary-calculator.ai/): Salary-Calculator.ai helps you compare net salaries worldwide instantly.


### PR DESCRIPTION
PDFExcel (https://pdfexcel.ai/) is an AI-powered tool that converts any PDF — including scanned and photographed documents — into clean Excel, CSV, or Google Sheets with no templates required. It is widely used by accountants, bookkeepers, and CPA firms for extracting financial data (bank statements, invoices, 1099s) from PDFs into spreadsheets.

Added to the Finance section in alphabetical order (between PayCalculator and Property Forecast), following the list's existing format: asterisk bullet, markdown link, colon, one-sentence description, period.