### PR TITLE
Add LLC Class to Legal & Services — Wyoming LLC for non-US founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [CitizenPY](https://societates-civis.com/citizenpy): Your step-by-step guide to claiming Paraguayan citizenship with smart tools.
 *   [CleanWhale](https://cleanwhale.us/): Effortless online booking for trusted, transparent home and office cleaning services.
 *   [FARSITE](https://far.site): Handle FAR & DFARS with smart features & clear guidance.
+*   [LLC Class](https://llcclass.com): [Wyoming LLC registration](https://llcclass.com/wyoming) for non-US founders — includes [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent), EIN, and Operating Agreement to unlock Stripe and Mercury bank access.
 *   [SignWith](https://signwith.co/): Sign documents without subscriptions. Pay per document.
 
 ### Marketing


### PR DESCRIPTION
## What's added

[LLC Class](https://llcclass.com) added to the **Legal & Services** section.

**What it does:** Wyoming LLC registration service for non-US founders who need a US legal entity — a common blocker when trying to access Stripe, Mercury bank, and US client contracts.

**What's included:**
- [Wyoming LLC filing](https://llcclass.com/wyoming) (state registration)
- [Registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent) (legally required US contact)
- EIN application
- Operating Agreement

This is a real micro-SaaS pain point: international founders often can't access Stripe without a US entity. LLC Class solves that step.