### PR TITLE
Add LLC Class to Legal & Services — Wyoming LLC for non-US founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [CitizenPY](https://societates-civis.com/citizenpy): Your step-by-step guide to claiming Paraguayan citizenship with smart tools.
 *   [CleanWhale](https://cleanwhale.us/): Effortless online booking for trusted, transparent home and office cleaning services.
 *   [FARSITE](https://far.site): Handle FAR & DFARS with smart features & clear guidance.
+*   [LLC Class](https://llcclass.com/wyoming): Wyoming LLC registration for non-US founders — includes registered agent, EIN, and operating agreement to start accepting Stripe and Mercury payments.
 *   [LLC Class](https://llcclass.com): [Wyoming LLC registration](https://llcclass.com/wyoming) for non-US founders — includes [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent), EIN, and Operating Agreement to unlock Stripe and Mercury bank access.
 *   [SignWith](https://signwith.co/): Sign documents without subscriptions. Pay per document.
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [CitizenPY](https://societates-civis.com/citizenpy): Your step-by-step guide to claiming Paraguayan citizenship with smart tools.
 *   [CleanWhale](https://cleanwhale.us/): Effortless online booking for trusted, transparent home and office cleaning services.
 *   [FARSITE](https://far.site): Handle FAR & DFARS with smart features & clear guidance.
+*   [LLC Class](https://llcclass.com): [Wyoming LLC registration](https://llcclass.com/wyoming) for non-US founders — includes [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent), EIN, and Operating Agreement to unlock Stripe and Mercury bank access.
 *   [SignWith](https://signwith.co/): Sign documents without subscriptions. Pay per document.
 
 ### Marketing


### PR DESCRIPTION
## What

Adds [LLC Class](https://llcclass.com/wyoming) to the **Legal & Services** section.

## Why

LLC Class is a specialized service for non-US residents and founders who need a US LLC to legally accept Stripe payments, open Mercury bank accounts, and work with US-based clients. It handles Wyoming LLC registration with registered agent, EIN filing, and operating agreement in one package.

Given this list targets Micro-SaaS builders — many of whom are international founders — LLC Class is a highly relevant tool in the legal services category.