### PR TITLE
feat: add CreatorSkills to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Convert.ai](https://convert.ai/): AI-powered platform that books qualified meetings with executive decision-makers fast.
 *   [CowboyQuote](https://cowboyquote.com/): Door-to-door sales with digital quotes and personalized customer interactions.
 *   [CrawlRaven](https://www.crawlraven.com/): Professional SEO audits with 200+ checks and prioritized fixes.
+*   [CreatorSkills](https://creatorskills.co): Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 *   [dnAI](https://humandnai.com/): Brand-first AI marketing platform.
 *   [Find Me Creators](https://www.findmecreators.com/database): The most powerful and affordable TikTok micro-influencer database.
 *   [Flowcart](https://flowcart.ai/): Flowcart helps B2C brands acquire, convert, retain customers on WhatsApp.


### PR DESCRIPTION
## What

Adds [CreatorSkills](https://creatorskills.co) to the **Marketing** section, alphabetically between CrawlRaven and dnAI.

## Why

CreatorSkills is a marketplace of 30+ downloadable AI skills targeting content creators — covering YouTube scripting, sponsorship analysis, audience growth workflows, and more. Skills are compatible with Claude and ChatGPT. It fits well in the Marketing category alongside tools like Find Me Creators and Social Growth Engineers.

## Entry added

```
*   [CreatorSkills](https://creatorskills.co): Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
```