### PR TITLE
Add GetAppNiche to marketing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [AI One Pager Generator](https://venngage.com/ai-tools/one-pager-generator): AI-powered one-pager designs, fast and effortless.
 *   [AI Roadmap Generator](https://venngage.com/ai-tools/roadmap-generator): AI Roadmap Generator creates a visual, step-by-step roadmap instantly.
 *   [Appark](https://appark.ai/en): Free app market analytics for growth and competition insights.
+*   [GetAppNiche](https://getappniche.com): iOS app market intelligence for revenue estimates, ASO keywords, reviews, and competitor research.
 *   [AppStore Tracker](https://appstoretracker.com/): An open AppStore Explorer.
 *   [Bazzly](https://www.bazzly.ai/): Get Customers From Reddit on Autopilot.
 *   [BigSpy](https://bigspy.com): Discover winning ad strategies by analyzing 1B+ ads across 9 social platforms.


### PR DESCRIPTION
## Summary
- Add GetAppNiche to the Marketing category.
- Keep the entry near related app market analytics tools.

## Disclosure
I am affiliated with GetAppNiche. I think it fits this list because it helps founders research iOS app niches, revenue potential, ASO keywords, reviews, and competitors.
