### PR TITLE
[codex] Add Markdown to Word

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Inbox Zapper](https://www.inboxzapper.com/): Your Digital Bouncer for Email Clutter.
 *   [Kenteken Gids](https://www.kentekengids.nl): Dutch Car License Plate Checker.
 *   [Mail Genie](https://mailgenie.io/): Clean your inbox by unsubscribing from newsletters and marketing emails.
+*   [Markdown to Word](https://mdtoword.org/): Convert Markdown into clean, editable DOCX files with live preview and local browser processing.
 *   [Me Bot](https://www.me.bot/): Turn your ideas into an AI life coach.
 *   [My Passion AI](https://mypassion.ai): AI-powered quiz to find your passion career path.
 *   [Night Mode](https://chromewebstore.google.com/detail/night-mode/ocjndlfidedijchleaiegckngmpcpjga): Night mode for Chrome: dark theme, yellow filter & text resize


### PR DESCRIPTION
## Summary

Adds Markdown to Word to the Productivity section of the curated tool list.

## Why

Markdown to Word fits the repository's micro-SaaS directory as a browser-based productivity tool for converting Markdown into editable DOCX documents with live preview and local processing.

## Checks

- Verified the entry follows the README contribution format.
- Verified the tool is placed alphabetically in the Productivity section.
- README-only change; no automated tests are needed.
