### PR TITLE
Add ReputeMap to marketing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Podify.io](https://podify.io): Leverage AI and community to grow on LinkedIn.
 *   [Pykaso.ai](https://www.pykaso.ai/): Create realistic AI influencers and monetize content through advanced generation tools.
 *   [ReelProof](https://reelproof.io): AI collects testimonials, creates shareable video reels, and boosts conversions.
+*   [ReputeMap](https://reputemap.com/review-management-software-for-agencies): Google review management software for agencies to monitor reviews, draft AI replies, request more reviews, and send white-label client reports.
 *   [SEO Katana](https://seokatana.com): Simplify SEO by analyzing competitors and generating effective content.
 *   [SaaSCurate](https://saascurate.com/): SaaSCurate helps SaaS founders promote products and grow through community exposure.
 *   [SalesAgent Chat](https://www.salesagent.chat/): AI-powered coach and assistant to boost confidence and close more deals.


### PR DESCRIPTION
Hi! I build ReputeMap, a Google review management tool for agencies and multi-location businesses.\n\nThis adds ReputeMap to the Marketing category. The section already includes review/testimonial and reputation-related tools such as Go Big Reviews, ReelProof, Say About Us, and Shosay, so ReputeMap fits as a micro-SaaS focused on Google review monitoring, AI replies, review requests, and white-label client reports.\n\nI kept the change to one concise entry in the existing list format.