### PR TITLE
Add AnswerLens to Marketing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [APAC Agencies](https://apacagencies.com): Discover the top creative and digital agencies in Asia Pacific.
 *   [AI One Pager Generator](https://venngage.com/ai-tools/one-pager-generator): AI-powered one-pager designs, fast and effortless.
 *   [AI Roadmap Generator](https://venngage.com/ai-tools/roadmap-generator): AI Roadmap Generator creates a visual, step-by-step roadmap instantly.
+*   [AnswerLens](https://app.sfdj.net/): Audits B2B SaaS public website evidence for pricing, proof, docs, comparison, trust, schema, and llms.txt gaps.
 *   [Appark](https://appark.ai/en): Free app market analytics for growth and competition insights.
 *   [AppStore Tracker](https://appstoretracker.com/): An open AppStore Explorer.
 *   [Bazzly](https://www.bazzly.ai/): Get Customers From Reddit on Autopilot.


### PR DESCRIPTION
Adds AnswerLens to the Marketing section.

I am connected to AnswerLens, so I am disclosing that here. The entry is a short factual listing for a B2B SaaS public-evidence audit tool. It does not claim rankings, AI citations, traffic, recommendations, conversion lift, revenue, sponsorship, affiliate status, or any guaranteed outcome.

I checked the README and open PRs/issues for existing AnswerLens or app.sfdj.net entries before opening this PR.