### PR TITLE
Add DDScore to Business tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Bricks](https://www.thebricks.com): AI-powered spreadsheet that simplifies complex tasks with natural language.
 *   [demonstro](https://demonstro.io/): Tinder for B2B sales: trade warm intros, skip cold outreach.
 *   [Digital Downloads App](https://digital-downloads-app.com): Digital Downloads App helps to deliver PDF, ebooks, and more to customers
+*   [DDScore](https://www.ddscore.ai/): Playful Pixels Oy's DDScore turns private-company materials into a structured 0–100 Due Diligence Score and full report.
 *   [ERP Pilot](https://www.erp-pilot.com/): Independent ERP Comparison Tool.
 *   [ExecHeadshots](https://execheadshots.com/): AI Headshot Generator for Professional Headshots.
 *   [FlowRunner](https://flow-runner.com/): FlowRunner runs your Salesforce Screen Flows inside Outlook and Gmail.


### PR DESCRIPTION
This adds one private-company analysis tool to the Business section using the repository's requested one-line format and a clean direct product URL.

I am directly involved in building DDScore at Playful Pixels Oy. DDScore turns private-company materials into a structured 0–100 Due Diligence Score and full written report. It supports first-pass analysis and human judgement. It does not provide investment advice or replace full due diligence.

No other tool or section is changed.
