### PR TITLE
Add SmartBizCalc to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Property Forecast](https://propertyforecast.co/): Data analytics for real estate investors.
 *   [Receipt Faker](https://receiptfaker.com/): Make receipts fast with easy templates you can edit and download.
 *   [Salary Calculator](https://salary-calculator.ai/): Salary-Calculator.ai helps you compare net salaries worldwide instantly.
+*   [SmartBizCalc](https://smartbizcalc.com/): 300+ free calculators for small businesses — taxes, payroll, pricing, insurance, and break-even analysis.
 *   [SMSF Buddy](https://smsfbuddy.com/): The private SMSF tracker for Australian trustees.
 *   [Tax Brackets](https://taxbrackets.io/): TaxBrackets.io instantly estimates global income taxes.
 *   [Tax Refund Calculator](https://taxrefund.pro/): A free online US tax calculator.


### PR DESCRIPTION
SmartBizCalc (https://smartbizcalc.com/) is a collection of 300+ free business calculators for small business owners — covering taxes, payroll, pricing, insurance, break-even analysis, and more. Fits naturally alongside PayCalculator, Tax Refund Calculator, and TaxBrackets in the Finance section.