### PR TITLE
Add GPTGeminiGrok.AI to AI & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Consul](https://consul.so/): Executive Assistant That Runs Your Calendar, Inbox & Scheduling.
 *   [FirmOS](https://www.firmos.ai/): AI-powered automation platform for accounting firms to streamline sales, hiring, and operations.
 *   [Foundy](https://www.foundy.com): Sell your business or find quality acquisitions.
+*   [GPTGeminiGrok.AI](https://trygrokai.asia/): Browser workspace for GPT, Gemini, Grok, Claude, and DeepSeek, with 10 free requests per day after signup.
 *   [Lisapet.ai](https://www.lisapet.ai): Simply and speed up AI product development for teams.
 *   [LocalChat.app](https://www.localchat.app/): Local-first MacOS AI application - 100% Private, Works Fully Offline.
 *   [Marblism](https://marblism.com/): AI team that automates content, sales, inbox, and scheduling tasks.


### PR DESCRIPTION
Adds GPTGeminiGrok.AI to the AI & Automation section in alphabetical order.

The one-line entry describes the supported model workspace and transparently states the current free allowance: 10 requests per day after account signup. No existing entries are changed.

Disclosure: I am submitting this on behalf of the product operator/creator.

https://trygrokai.asia/