### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [KarmaLinks](https://karmalinks.io/): AI-driven platform for free, quality backlink exchange and SEO.
 *   [Keyla.AI](https://keyla.ai/): Create high performing, scalable ads with realistic AI avatars.
 *   [Kimblur](https://kimblur.com/): AI-powered presentation maker.
+*   [Klinky](https://klinky.io/): A/B testing link shortener — split one link between two destinations and measure which one wins.
 *   [Learn Copywriting](https://learncopywriting.com/): Practice copywriting with AI.
 *   [Linkter](https://www.linkter.ai/): #1 AI Internal Linking Tool For SEO Superstars.
 *   [Lunroo](https://lunroo.com): Free AI Tools for Social Media Marketing.


### PR DESCRIPTION
Adds [Klinky](https://klinky.io/) to the Marketing category, in alphabetical order.

Klinky is a bootstrapped micro-SaaS (solo founder): an A/B testing link shortener that splits one short link between two destinations at chosen weights, with real-time click analytics to compare variants. Entry follows the list's existing format and one-category rule.
