### PR TITLE
Add Shopify App Review Brief to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [SalesStatsVisualize](https://salesstatsvisualize.com): Etsy Sales Simplified - Easy Listing, Deep Analysis.
 *   [Salesably](https://www.salesably.ai/): AI-driven sales coaching to enhance communication.
 *   [Say About Us](https://sayabout.us/): Collect unlimited video and text testimonials.
+*   [Shopify App Review Brief](https://alfredtech2026.github.io/shopify-app-review-brief/?utm_source=best-micro-saas-tools&utm_medium=resource-directory&utm_campaign=inbound-validation): Human-checked, prioritized low-star review briefs for Shopify app teams.
 *   [Shosay](https://www.shosay.com): AI tool that collects and displays customer reviews in one place.
 *   [Shortimize](https://shortimize.com/): Track, Analyze & Explore short form content videos and accounts.
 *   [Slate](https://slatehq.com/): Automation platform for SEO, Web and Content Teams.


### PR DESCRIPTION
Adds one entry to the **Marketing** category for Shopify App Review Brief.

### Disclosure

- I maintain the linked resource, so this is a self-submission. Please weigh it accordingly, and I am happy to amend or withdraw it if it is not a fit for the directory.
- The linked URL carries `utm_source` / `utm_medium` / `utm_campaign` source-attribution parameters so I can see referrals from this directory. Happy to drop them if you prefer clean links.
- Claude Code assisted with preparing this contribution.

### What changed

- One file changed: `README.md`, one line inserted, nothing deleted or reordered.
- Follows the contribution format from the README: `* [Product Name](Product Link): Short description.`
- Placed in alphabetical position within Marketing, after `Say About Us` and before `Shortimize` / `Shosay`.
- Neutral description with no pricing, customer counts, or testimonial claims.

```
*   [Shopify App Review Brief](https://alfredtech2026.github.io/shopify-app-review-brief/?utm_source=best-micro-saas-tools&utm_medium=resource-directory&utm_campaign=inbound-validation): Human-checked, prioritized low-star review briefs for Shopify app teams.
```

### What it is

A concierge service for independent Shopify app teams: new 1-3 star reviews on their apps and named competitors are turned into one prioritized, human-checked product and support brief.

Link returns HTTP 200 with no redirects. Let me know if you would like the wording, category, or placement adjusted.