### PR TITLE
Add QuoteChime to Business tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Plotzy](https://plotzy.ai): AI Co-Pilot For The Commercial Real Estate Industry.
 *   [ProxDeal](https://proxdeal.com): AI tool simplifies M&A research, target identification, and personalized outreach.
 *   [Pulsed](https://www.pulsed.me/): Free interactive platform for creating live polls with real-time feedback.
+*   [QuoteChime](https://quotechime.pages.dev/?ref=best-micro-saas-tools): Browser-private quote follow-up drafts and one-time script packs for small service businesses.
 *   [Redii](https://www.redii.co/): Retirement benefits for your global workforce.
 *   [Receipts Maker](https://receiptsmaker.com): Online receipt generator.
 *   [RentalFinder](https://www.rentalfinder.nl/): Automatic rental finder for Dutch homes with alerts and smart search.


### PR DESCRIPTION
Adds QuoteChime in alphabetical order under **Business**.

QuoteChime is a live browser-private quote follow-up generator for small service businesses. The generator is free; optional script packs are one-time purchases with no subscription.

- Product: https://quotechime.pages.dev/
- Open-source standalone generator: https://github.com/eswain89-web/quotechime-free

This PR changes one list entry and follows the repository's existing format.