### PR TITLE
Add ClearSheet to Business tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 
 *   [Alquilame](https://alquilame.io/): Simple rental management with WhatsApp booking and zero commission fees.
 *   [Bricks](https://www.thebricks.com): AI-powered spreadsheet that simplifies complex tasks with natural language.
+*   [ClearSheet](https://me-fake-you.github.io/clearsheet-offers/): Turn invoices, purchase orders, and freight documents into clean, review-ready Excel workbooks.
 *   [demonstro](https://demonstro.io/): Tinder for B2B sales: trade warm intros, skip cold outreach.
 *   [Digital Downloads App](https://digital-downloads-app.com): Digital Downloads App helps to deliver PDF, ebooks, and more to customers
 *   [ERP Pilot](https://www.erp-pilot.com/): Independent ERP Comparison Tool.


### PR DESCRIPTION
## Summary

Adds ClearSheet to the Business category using the repository's required one-line format and alphabetical order.

## Fit and disclosure

ClearSheet is a privacy-first document-to-Excel service with a public structure-only compatibility check and synthetic workbook examples. The listing describes the service directly and makes no customer, accuracy, or performance claim.

I am submitting the project's own listing.