### PR TITLE
Add XiuRouter to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [TestSprite](https://www.testsprite.com/): The most powerful AI testing tool for testing, fixing, and validating your software in one automated flow.
 *   [Type Think AI](https://typethink.ai/): Your Gateway to AI Models & Tools.
 *   [Work Type Focus](https://worktypefocus.com/): Classify and visualize Jira work to stay focused and foster innovation.
+*   [XiuRouter](https://router.xiu.ai/): Connects apps and AI agents to leading models through OpenAI Responses and Chat Completions, Anthropic Messages, and Gemini GenerateContent, with scoped keys and request-level usage and cost records.
 *   [Zuzia.app](https://zuzia.app/): Monitor Linux servers, automate tasks, and get alerts — no SSH needed.
 *   [staarter.dev](https://staarter.dev): Next.js SaaS Boilerplate.
 


### PR DESCRIPTION
## Summary

- add XiuRouter to the Developer Tools section
- keep the entry to one neutral, verifiable line
- link directly to the public product page

## Validation

- confirmed XiuRouter and `router.xiu.ai` do not appear in the current README, code search, issues, or pull requests
- confirmed the product and documentation URLs return HTTP 200
- verified the README contains one XiuRouter entry after the change
- `git diff --check` passed

I am affiliated with XiuRouter and XiuLab Inc. AI assistance was used to prepare the contribution; the final text and diff were reviewed before submission.