### PR TITLE
Add Hermes to Customer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [AudioForms](https://getaudioforms.com/): Capture detailed voice feedback easily with automatic transcription and simple sharing.
 *   [Beheard Labs](https://www.gobeheard.com/): AI-Powered Customer Insight Platform
 *   [Chat Thing](http://chatthing.ai/): Make AI chatbots in minutes.
+*   [Hermes](https://buildwithhermes.com): Voice AI agents that agencies deploy for clients under their own brand.
 *   [Keeping](https://www.keeping.com/): Turns Google Workspace Into Your Team’s Help Desk.
 *   [Owlbot](https://www.owlbot.ai/): AI Support Agent.
 *   [Rosie](https://heyrosie.com/): AI Phone Answering Service.


### PR DESCRIPTION
Adds one entry to **Customer Support**, alphabetically between Chat Thing and Keeping.

```
*   [Hermes](https://buildwithhermes.com): Voice AI agents that agencies deploy for clients under their own brand.
```

Why this category rather than AI & Automation: the section already carries Rosie, VirtualReception.AI and Swiftsell AI, so phone answering is an established fit here. Hermes sits one layer under those. Rosie and VirtualReception.AI answer calls for one business. Hermes is the platform an agency runs to deploy and bill those agents across many client businesses, white labelled, so their clients never see the Hermes name.

Kept to the house format: `*   [Product Name](Product Link): Short description.`, single line, alphabetical, one tool in one category. Diff is +1/-0.

Pricing is public and self serve at three tiers, $149, $399 and $699 per month, each with included minutes, so it is a real micro SaaS price point rather than a call for quote.

Disclosure: I work on Hermes.