### PR TITLE
Add LovedByAI to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [Kimblur](https://kimblur.com/): AI-powered presentation maker.
 *   [Learn Copywriting](https://learncopywriting.com/): Practice copywriting with AI.
 *   [Linkter](https://www.linkter.ai/): #1 AI Internal Linking Tool For SEO Superstars.
+*   [LovedByAI](https://www.lovedby.ai/): Set-and-forget AI search optimization plugin for WordPress.
 *   [Lunroo](https://lunroo.com): Free AI Tools for Social Media Marketing.
 *   [Luthor](https://luthor.ai/): Grow organic traffic with programmatic SEO at scale.
 *   [ManuscriptReport](https://manuscriptreport.com/): Generate complete book marketing kits with blurbs, comps, ads, and more.


### PR DESCRIPTION
Adds one tool to the **Marketing** category.

```
*   [LovedByAI](https://www.lovedby.ai/): Set-and-forget AI search optimization plugin for WordPress.
```

**What it is:** a WordPress plugin that makes existing pages readable and citable by AI assistants (ChatGPT, Perplexity, Claude, Gemini) — schema, FAQ markup, a generated `llms.txt`, and instant indexing of changes. It does not generate content; it makes the content you have machine-readable.

**Why Marketing:** it sits alongside the other SEO/GEO entries in that section, such as Linkter, Luthor and Soro.

**Checklist**
- [x] Added to the most relevant category (Marketing)
- [x] Alphabetical order preserved (between Linkter and Lunroo)
- [x] Uses the required format: `* [Product Name](Product Link): Short description.`
- [x] Single-line change, no other edits

Live on the WordPress.org plugin directory: https://wordpress.org/plugins/lovedbyai-seo-for-llms-and-ai-search/