### PR TITLE
Add InkCraft to Health & Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ A curated list of awesome tools for marketing, development, productivity, and mo
 *   [DreamjourneyAI](https://dreamjourneyai.com): Explore fantasies with AI roleplay, character chats, and RPGs.
 *   [FamilyPro](https://familypro.io): Enjoy premium subscriptions for lowest price with FamilyPro.
 *   [Flirt](https://flirtos.com/): Craft perfect dating app responses, build standout profiles, and spark meaningful connections.
+*   [InkCraft](https://inkcraftapp.com): Preview tattoos on your own photo, and on a 3D model of your body reconstructed from that photo.
 *   [mealideas](https://mealideas.ai/): AI-powered meal decisions that learn your taste.
 *   [Medidex Connect](https://medidex.chat): Chat with a pharmacist online.
 *   [MyNextInk](https://www.mynextink.com): The all-in-one tattoo platform


### PR DESCRIPTION
Adds InkCraft to Health & Lifestyle, placed alphabetically between Flirt and mealideas, in the format given in the Contributing section.

InkCraft is a tattoo try-on: you upload a photo of yourself and a design is placed on your skin following the body contour rather than sitting flat. From that same photo it reconstructs a 3D model of your body, so a placement can be judged from angles the photo never showed. The browser version works without an account.

Disclosure: I'm the developer.